### PR TITLE
Correct path to linters directory

### DIFF
--- a/TEMPLATES/README.md
+++ b/TEMPLATES/README.md
@@ -1,6 +1,6 @@
 # TEMPLATES
 
-The files in this folder are template rules for the linters that will run against your code base. If you chose to copy these to your local repository in the directory: `.github/` they will be used at runtime. If they are not present, they will be used by default in the linter run.
+The files in this folder are template rules for the linters that will run against your code base. If you chose to copy these to your local repository in the directory: `.github/linters` they will be used at runtime. If they are not present, they will be used by default in the linter run.
 
 The file(s) will be parsed at run time on the local branch to load all rules needed to run the **Super-Linter** **GitHub** Action.
 The **GitHub** Action will inform the user via the **Checks API** on the status and success of the process.


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Update path to the linters directory in the `TEMPLATES/README.md`, making it consistent with the main `README.md`

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
